### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-AndroidClient
-=============
+# AndroidClient
 
-Team
-----
+## Team
 
 **Devs**
 - Amit Bharadwaj (@amitbharadwaj)
@@ -13,7 +11,13 @@ Team
 - Jairo Avalos (@jairoavalos)
 - Tom Gurka (@tomgurka)
 
-License
--------
+## Setup Instructions
+1. Clone the repository
+`git clone https://github.com/CodePath-MAF/AndroidClient.git`
+
+2. Edit the config file
+Rename `res/values/app_config_sample.xml` to `res/values/app_config.xml` and add in the Parse Application & Client ID for the project.
+
+## License
 
 All code is distributed under MIT license. See LICENSE file for more information.


### PR DESCRIPTION
Add short setup instructions for the app_config.xml file.

@fcduarte & @amitbharadwaj you guys should have access to our Parse Project to fetch the application and client ID from https://www.parse.com/apps/codepath-maf/edit#settings
